### PR TITLE
Make metadata more general

### DIFF
--- a/features/AbstractAPI.py
+++ b/features/AbstractAPI.py
@@ -61,7 +61,7 @@ class AbstractFeatureRow(object):
 
 class AbstractFeatureStore(object):
     """
-    A single feature store
+    A single feature store including metadata columns
 
     Each entry in a feature store consists of a FeatureRow
     """
@@ -69,59 +69,30 @@ class AbstractFeatureStore(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def store_by_image(self, image_id, values):
+    def store(self, meta, values):
         """
-        Store a single FeatureRow by Image ID
+        Store a single FeatureRow
 
-        :param image_id: The Image ID
+        :param meta: The metadata values
         :param values: The feature values
         """
         pass
 
     @abstractmethod
-    def store_by_roi(self, roi_id, values):
+    def fetch_by_metadata(self, meta, raw=False):
         """
-        Store a single FeatureRow by Image ID
+        Retrieve FeatureRows by matching metadata
 
-        :param image_id: The Image ID
-        :param values: The feature values
-        """
-        pass
-
-    @abstractmethod
-    def fetch_by_image(self, image_id):
-        """
-        Retrieve a single FeatureRow by Image ID
-
-        :param image_id: The Image ID
-        :return: A FeatureRow
-        """
-        pass
-
-    @abstractmethod
-    def fetch_by_roi(self, roi_id):
-        """
-        Retrieve a single FeatureRow by ROI ID
-
-        :param roi_id: The ROI ID
-        :return: A FeatureRow
-        """
-        pass
-
-    @abstractmethod
-    def fetch_all(self, image_id):
-        """
-        Retrieve all rows of features identified by Image ID
-
-        :param image_id: The Image ID
-        :return: A list of FeatureRows
+        :param meta: Either a dict of fieldname=value, or an array of
+               metadata values to be match (use <None> to ignore a column)
+        :return: FeatureRows
         """
         pass
 
     @abstractmethod
     def filter(self, conditions):
         """
-        Retrieve the features and Image/ROI IDs which fulfill the conditions
+        Retrieve the features which fulfill the conditions
 
         :param conditions: The feature query conditions
         :return: A list of FeatureRows

--- a/features/OmeroTablesFeatureStore.py
+++ b/features/OmeroTablesFeatureStore.py
@@ -243,15 +243,16 @@ class FeatureTable(AbstractFeatureStore):
     """
 
     def __init__(self, session, name, ft_space, ann_space, ownerid,
-                 metadesc=None, coldesc=None, noopen=False):
+                 metadesc=None, coldesc=None, ofileid=None, noopen=False):
         """
         :param session: An OMERO session
         :param name: The feature table name
         :param ft_space: The feature table namespace
         :param ann_space: The feature annotation namespace
         :param ownerid: User ID of the table owner
-        :param metadesc: See :meth:`new_table`
-        :param coldesc: See :meth:`new_table`
+        :param metadesc: See :meth:`open_or_create_table`
+        :param coldesc: See :meth:`open_or_create_table`
+        :param ofileid: See :meth:`open_or_create_table`
         :param noopen: Don't automatically open a table (manually call
             :meth:new_table or :meth:open_table)
         """
@@ -269,7 +270,7 @@ class FeatureTable(AbstractFeatureStore):
         self.editable = None
         if not noopen:
             self.open_or_create_table(
-                ownerid, metadesc=metadesc, coldesc=coldesc)
+                ownerid, metadesc=metadesc, coldesc=coldesc, ofileid=ofileid)
 
     def _owns_table(func):
         def assert_owns_table(*args, **kwargs):

--- a/features/OmeroTablesFeatureStore.py
+++ b/features/OmeroTablesFeatureStore.py
@@ -29,7 +29,7 @@ import omero
 import omero.clients
 from omero.rtypes import unwrap, wrap
 
-import itertools
+from itertools import izip
 import json
 import re
 
@@ -599,12 +599,12 @@ class FeatureTable(AbstractFeatureStore):
         if len(values) != ft_len:
             raise TableUsageException('Expected %d feature values' % ft_len)
 
-        for n in self.metacols:
-            cols[n].values.append(meta[n])
+        for n, m in izip(self.metacols, xrange(meta_len)):
+            cols[n].values.append(meta[m])
 
         if self.singleftcols:
-            for n in self.singleftcols:
-                cols[n].values.append(meta[n])
+            for n, v in izip(self.singleftcols, xrange(ft_len)):
+                cols[n].values.append(values[v])
         else:
             p = 0
             for n in self.multiftcols:
@@ -771,7 +771,7 @@ class FeatureTable(AbstractFeatureStore):
             if values is None:
                 values = [c.values for c in data.columns]
             else:
-                for c, v in itertools.izip(data.columns, values):
+                for c, v in izip(data.columns, values):
                     v.extend(c.values)
 
         return values

--- a/features/OmeroTablesFeatureStore.py
+++ b/features/OmeroTablesFeatureStore.py
@@ -243,7 +243,7 @@ class FeatureTable(AbstractFeatureStore):
     """
 
     def __init__(self, session, name, ft_space, ann_space, ownerid,
-                 coldesc=None):
+                 metadesc=None, coldesc=None):
         self.session = session
         self.perms = PermissionsHandler(session)
         self.name = name
@@ -254,7 +254,7 @@ class FeatureTable(AbstractFeatureStore):
         self.metanames = None
         self.ftnames = None
         self.chunk_size = None
-        self.get_table(ownerid, coldesc=coldesc)
+        self.get_table(ownerid, metadesc=metadesc, coldesc=coldesc)
 
     def _owns_table(func):
         def assert_owns_table(*args, **kwargs):
@@ -727,7 +727,7 @@ class FeatureTableManager(AbstractFeatureStoreManager):
         self.cachesize = kwargs.get('cachesize', 10)
         self.fss = LRUClosableCache(kwargs.get('cachesize', 10))
 
-    def create(self, featureset_name, names):
+    def create(self, featureset_name, metadesc, names):
         try:
             ownerid = self.session.getAdminService().getEventContext().userId
             fs = self.get(featureset_name, ownerid)
@@ -740,7 +740,7 @@ class FeatureTableManager(AbstractFeatureStoreManager):
         coldesc = names
         fs = FeatureTable(
             self.session, featureset_name, self.ft_space, self.ann_space,
-            ownerid, coldesc)
+            ownerid, metadesc, coldesc)
         self.fss.insert((featureset_name, ownerid), fs)
         return fs
 

--- a/features/OmeroTablesFeatureStore.py
+++ b/features/OmeroTablesFeatureStore.py
@@ -254,12 +254,16 @@ class FeatureTable(AbstractFeatureStore):
         self.metanames = None
         self.ftnames = None
         self.chunk_size = None
+        self.editable = None
         self.get_table(ownerid, metadesc=metadesc, coldesc=coldesc)
 
     def _owns_table(func):
         def assert_owns_table(*args, **kwargs):
             self = args[0]
-            if not self.perms.can_edit(self.table.getOriginalFile()):
+            if self.editable is None:
+                self.editable = self.perms.can_edit(
+                    self.table.getOriginalFile())
+            if not self.editable:
                 raise FeaturePermissionException(
                     'Feature table must be owned by the current user')
             return func(*args, **kwargs)
@@ -274,6 +278,7 @@ class FeatureTable(AbstractFeatureStore):
             self.table = None
             self.cols = None
             self.ftnames = None
+            self.editable = None
 
     def get_table(self, ownerid, metadesc=None, coldesc=None):
         """

--- a/features/OmeroTablesFeatureStore.py
+++ b/features/OmeroTablesFeatureStore.py
@@ -577,8 +577,11 @@ class FeatureTable(AbstractFeatureStore):
                Note the query syntax is still to be decided
         :return: A list of tuples (Image-ID, Roi-ID, feature-values)
         """
-        offsets = self.table.getWhereList(
-            conditions, {}, 0, self.table.getNumberOfRows(), 0)
+        if conditions:
+            offsets = self.table.getWhereList(
+                conditions, {}, 0, self.table.getNumberOfRows(), 0)
+        else:
+            offsets = range(self.table.getNumberOfRows())
         values = self.chunked_table_read(offsets, self.get_chunk_size())
 
         # Convert into row-wise storage

--- a/test/integration/test_table_feature_store.py
+++ b/test/integration/test_table_feature_store.py
@@ -46,6 +46,7 @@ class FeatureTableProxy(OmeroTablesFeatureStore.FeatureTable):
         self.metanames = None
         self.ftnames = None
         self.header = None
+        self.editable = None
         self.chunk_size = None
 
 

--- a/test/integration/test_table_feature_store.py
+++ b/test/integration/test_table_feature_store.py
@@ -42,6 +42,7 @@ class FeatureTableProxy(OmeroTablesFeatureStore.FeatureTable):
         self.ft_space = ft_space
         self.ann_space = ann_space
         self.cols = None
+        self.colnamemap = None
         self.pendingcols = None
         self.table = None
         self.metanames = None

--- a/test/integration/test_table_feature_store.py
+++ b/test/integration/test_table_feature_store.py
@@ -419,16 +419,27 @@ class TestFeatureTable(TableStoreTestHelper):
 
         store.close()
 
-    def test_filter_raw(self):
+    @pytest.mark.parametrize('emptyquery', [True, False])
+    def test_filter_raw(self, emptyquery):
         tid = self.create_table_for_fetch(owned=True, width=1)
 
         store = FeatureTableProxy(
             self.sess, self.name, self.ft_space, self.ann_space)
         store.open_table(omero.model.OriginalFileI(tid))
 
-        rvalues = store.filter_raw('(ImageID==13) | (RoiID==34)')
-        assert len(rvalues) == 2
-        assert sorted(rvalues) == [(-1, 34, [90]), (13, -1, [30])]
+        if emptyquery:
+            rvalues = store.filter_raw('')
+            assert len(rvalues) == 4
+            assert sorted(rvalues) == [
+                (-1, 34, [90]),
+                (12, -1, [10]),
+                (12, 56, [20]),
+                (13, -1, [30]),
+                ]
+        else:
+            rvalues = store.filter_raw('(ImageID==13) | (RoiID==34)')
+            assert len(rvalues) == 2
+            assert sorted(rvalues) == [(-1, 34, [90]), (13, -1, [30])]
 
         store.close()
 

--- a/test/unit/test_table_feature_store.py
+++ b/test/unit/test_table_feature_store.py
@@ -564,6 +564,27 @@ class TestFeatureTable(object):
 
         return store, table, meta, values, expectedcols
 
+    def test_get_condition(self):
+        store = MockFeatureTable(None)
+        store.cols = [
+            MockColumn(name='a'), omero.grid.StringColumn(name='b', size=8),
+            MockColumn(name='c', size=1)]
+
+        assert store._get_condition('a', None) is None
+        assert store._get_condition('a', [None, None]) is None
+        assert store._get_condition('a', 1) == '(a==1)'
+        assert store._get_condition('a', [1]) == '((a==1))'
+        assert store._get_condition('a', (1,)) == '((a==1))'
+        assert store._get_condition('a', [1, 2]) == '((a==1) | (a==2))'
+        assert store._get_condition('a', (1, None, 2)) == '((a==1) | (a==2))'
+
+        assert store._get_condition('b', 'ab') == '(b=="ab")'
+        assert store._get_condition('b', 'a"b') == '(b=="a\\"b")'
+        assert store._get_condition('b', ['a', None]) == '((b=="a"))'
+        assert store._get_condition('b', ['a', '']) == '((b=="a") | (b==""))'
+        assert store._get_condition('b', ['a"b', '', 'c " " d']) == (
+            '((b=="a\\"b") | (b=="") | (b=="c \\" \\" d"))')
+
     @pytest.mark.parametrize('exists', [True, False])
     def test_store(self, exists):
         store, table, meta, values, expectedcols = self.setup_test_store()

--- a/test/unit/test_table_feature_store.py
+++ b/test/unit/test_table_feature_store.py
@@ -1142,13 +1142,15 @@ class TestOmeroTablesFeatureStore(object):
                     params, o))).AndReturn([mf])
 
         self.mox.ReplayAll()
-        result = OmeroTablesFeatureStore.list_tables(
-            session, name, ft_space, None, ownerid, None)
         if name or ft_space or ownerid > -1:
+            result = OmeroTablesFeatureStore.list_tables(
+                session, name, ft_space, None, ownerid, None)
             assert len(result) == 1
             assert result[0] == (1L, name, ft_space, None)
         else:
-            assert result == []
+            with pytest.raises(OmeroTablesFeatureStore.OmeroTableException):
+                result = OmeroTablesFeatureStore.list_tables(
+                    session, name, ft_space, None, ownerid, None)
 
         self.mox.VerifyAll()
 

--- a/test/unit/test_table_feature_store.py
+++ b/test/unit/test_table_feature_store.py
@@ -864,20 +864,21 @@ class TestFeatureTableManager(object):
         fs = MockFeatureTable(None)
         self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'FeatureTable')
         fsname = 'fsname'
+        meta = [('Float', 'f')]
         colnames = ['x1', 'x2']
 
         OmeroTablesFeatureStore.FeatureTable(
             session, fsname, 'x/features', 'x/source', ownerid).AndReturn(None)
 
         OmeroTablesFeatureStore.FeatureTable(
-            session, fsname, 'x/features', 'x/source', ownerid, colnames
+            session, fsname, 'x/features', 'x/source', ownerid, meta, colnames
             ).AndReturn(fs)
 
         self.mox.ReplayAll()
 
         fts = OmeroTablesFeatureStore.FeatureTableManager(
             session, namespace='x')
-        assert fts.create(fsname, colnames) == fs
+        assert fts.create(fsname, meta, colnames) == fs
 
         assert len(fts.fss) == 1
         assert fts.fss.get((fsname, ownerid)) == fs

--- a/test/unit/test_table_feature_store.py
+++ b/test/unit/test_table_feature_store.py
@@ -1181,16 +1181,17 @@ class TestFeatureTableManager(object):
         ownerid = 123
         session = MockSession(None, None, ownerid)
         fs = MockFeatureTable(None)
-        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'FeatureTable')
+        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'list_tables')
+        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'new_table')
         fsname = 'fsname'
         meta = [('Float', 'f')]
         colnames = ['x1', 'x2']
 
-        OmeroTablesFeatureStore.FeatureTable(
-            session, fsname, 'x/features', 'x/source', ownerid).AndReturn(None)
+        OmeroTablesFeatureStore.list_tables(
+            session, fsname, 'x/features', ownerid=ownerid).AndReturn([])
 
-        OmeroTablesFeatureStore.FeatureTable(
-            session, fsname, 'x/features', 'x/source', ownerid, meta, colnames
+        OmeroTablesFeatureStore.new_table(
+            session, fsname, 'x/features', 'x/source', meta, colnames
             ).AndReturn(fs)
 
         self.mox.ReplayAll()
@@ -1210,7 +1211,8 @@ class TestFeatureTableManager(object):
         session = MockSession(None, None, ownerid)
         fs = MockFeatureTable(session)
         fs.table = object()
-        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'FeatureTable')
+        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'list_tables')
+        self.mox.StubOutWithMock(OmeroTablesFeatureStore, 'open_table')
         fsname = 'fsname'
         fts = OmeroTablesFeatureStore.FeatureTableManager(
             session, namespace='x')
@@ -1228,9 +1230,12 @@ class TestFeatureTableManager(object):
             if state == 'closed':
                 fsold = MockFeatureTable(None)
                 fts.fss.get(k).AndReturn(fsold)
-            OmeroTablesFeatureStore.FeatureTable(
-                session, fsname, 'x/features', 'x/source', ownerid
-                ).AndReturn(fs)
+
+            r = (1234, None, None, None)
+            OmeroTablesFeatureStore.list_tables(
+                session, fsname, 'x/features', ownerid=ownerid).AndReturn([r])
+            OmeroTablesFeatureStore.open_table(
+                session, r[0], 'x/source').AndReturn(fs)
             fts.fss.insert(k, fs)
 
         self.mox.ReplayAll()

--- a/test/unit/test_table_feature_store.py
+++ b/test/unit/test_table_feature_store.py
@@ -254,6 +254,7 @@ class MockFeatureTable(OmeroTablesFeatureStore.FeatureTable):
         self.metanames = None
         self.ftnames = None
         self.header = None
+        self.editable = None
         self.chunk_size = None
 
 


### PR DESCRIPTION
Remove the default ImageID and RoiID columns, instead make the metadata columns en tirely user-defined. See https://github.com/ome/omero-features/wiki/IDR-use-cases
